### PR TITLE
Epic 2 - filter events

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK" />
+  <component name="VisualizationToolProject">
+    <option name="state">
+      <ProjectState>
+        <option name="scale" value="0.17609375" />
+      </ProjectState>
+    </option>
+  </component>
 </project>

--- a/app/src/androidTest/java/com/example/ticketreservationapp/EventQueryBuilderInstrumentedTest.java
+++ b/app/src/androidTest/java/com/example/ticketreservationapp/EventQueryBuilderInstrumentedTest.java
@@ -1,0 +1,57 @@
+package com.example.ticketreservationapp;
+
+import static org.junit.Assert.assertNotNull;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.Query;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Calendar;
+
+@RunWith(AndroidJUnit4.class)
+public class EventQueryBuilderInstrumentedTest{
+
+    private CollectionReference eventsRef;
+
+    @Before
+    public void setUp() {
+        FirebaseApp.initializeApp(
+                androidx.test.platform.app.InstrumentationRegistry.getInstrumentation().getTargetContext()
+        );
+
+        eventsRef = FirebaseFirestore.getInstance().collection("events");
+        assertNotNull(eventsRef);
+    }
+
+    @Test
+    public void build_none_returnsQuery() {
+        Query q = EventQueryBuilder.build(eventsRef, EventFilter.none());
+        assertNotNull(q);
+    }
+
+    @Test
+    public void build_locationPrefix_returnsQuery() {
+        Query q = EventQueryBuilder.build(eventsRef, EventFilter.locationPrefix("Cir"));
+        assertNotNull(q);
+    }
+
+    @Test
+    public void build_category_returnsQuery() {
+        Query q = EventQueryBuilder.build(eventsRef, EventFilter.category("SPORTS"));
+        assertNotNull(q);
+    }
+
+    @Test
+    public void build_singleDate_returnsQuery() {
+        Calendar c = Calendar.getInstance();
+        Query q = EventQueryBuilder.build(eventsRef, EventFilter.singleDate(c));
+        assertNotNull(q);
+    }
+}

--- a/app/src/main/java/com/example/ticketreservationapp/AdminActivity.java
+++ b/app/src/main/java/com/example/ticketreservationapp/AdminActivity.java
@@ -31,6 +31,7 @@ import com.google.firebase.firestore.Query;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 
 public class AdminActivity extends AppCompatActivity {
@@ -177,19 +178,28 @@ public class AdminActivity extends AppCompatActivity {
             int maxPlaces = Integer.parseInt(maxStr);
             Timestamp date = new Timestamp(calendar.getTime());
 
+            // normalize for filtering
+            String locationSmallCaps = location.toLowerCase(Locale.getDefault());
+            String categoryBigCaps = category.toUpperCase(Locale.getDefault());
+
+            Map<String, Object> data = new java.util.HashMap<>();
+            data.put("name", name);
+            data.put("location", location);
+            data.put("locationLower", locationSmallCaps);
+            data.put("category", categoryBigCaps);
+            data.put("maxPlaces", maxPlaces);
+            data.put("date", date);
+
+
             if (isEdit) { // Update existing document
-                event.setName(name);
-                event.setLocation(location);
-                event.setCategory(category);
-                event.setMaxPlaces(maxPlaces);
-                event.setDate(date);
-                eventsRef.document(event.getId()).set(event).addOnSuccessListener(aVoid -> {
+                data.put("reservedPlaces", event.getReservedPlaces());
+                eventsRef.document(event.getId()).set(data).addOnSuccessListener(aVoid -> {
                     Toast.makeText(this, "Event Updated!", Toast.LENGTH_SHORT).show();
                     dialog.dismiss();
                 });
             } else { // Create brand new document
-                Event newEvent = new Event(name, date, location, category, 0, maxPlaces);
-                eventsRef.add(newEvent).addOnSuccessListener(ref -> {
+                data.put("reservedPlaces", 0);
+                eventsRef.add(data).addOnSuccessListener(ref -> {
                     Toast.makeText(this, "Event Added!", Toast.LENGTH_SHORT).show();
                     dialog.dismiss();
                 });

--- a/app/src/main/java/com/example/ticketreservationapp/EventAdapter.java
+++ b/app/src/main/java/com/example/ticketreservationapp/EventAdapter.java
@@ -21,22 +21,29 @@ public class EventAdapter extends FirestoreRecyclerAdapter<Event, EventAdapter.E
     private static final String AVAILABLE_EVENT_MESSAGE = "Tickets available";
     private final boolean isAdminMode;
     private final ReserveListener reserveListener;
+    private final EmptyStateListener emptyStateListener;
 
     @FunctionalInterface
     public interface ReserveListener {
         void onReserve(Event event, int quantity);
     }
-
-    public EventAdapter(@NonNull FirestoreRecyclerOptions<Event> options, ReserveListener reserveListener) {
+    public interface EmptyStateListener {
+        void onEmptyStateChanged(boolean isEmpty);
+    }
+    public EventAdapter(@NonNull FirestoreRecyclerOptions<Event> options, ReserveListener reserveListener, EmptyStateListener emptyStateListener) {
         super(options);
         this.isAdminMode = false;
         this.reserveListener = reserveListener;
+        this.emptyStateListener = emptyStateListener;
     }
-
+    public EventAdapter(@NonNull FirestoreRecyclerOptions<Event> options, ReserveListener reserveListener) {
+        this(options, reserveListener, null);
+    }
     public EventAdapter(@NonNull FirestoreRecyclerOptions<Event> options) {
         super(options);
         this.isAdminMode = true;
         this.reserveListener = null;
+        this.emptyStateListener = null;
     }
 
     @Override
@@ -53,7 +60,13 @@ public class EventAdapter extends FirestoreRecyclerAdapter<Event, EventAdapter.E
         View v = layoutInflater.inflate(R.layout.item_event, parent, false);
         return new EventHolder(v);
     }
-
+    @Override
+    public void onDataChanged() {
+        super.onDataChanged();
+        if (emptyStateListener != null) {
+            emptyStateListener.onEmptyStateChanged(getItemCount() == 0);
+        }
+    }
     class EventHolder extends RecyclerView.ViewHolder {
         private final TextView tvName, tvCategory, tvLocation, tvDateTime, tvReservedPlaces, tvMaxPlaces, tvAvailabilityStatus;
         private final TextView tvTicketQuantity;

--- a/app/src/main/java/com/example/ticketreservationapp/EventFilter.java
+++ b/app/src/main/java/com/example/ticketreservationapp/EventFilter.java
@@ -1,0 +1,24 @@
+package com.example.ticketreservationapp;
+
+import java.util.Calendar;
+
+public record EventFilter(Type type, String text, Calendar day) {
+
+    public enum Type {NONE, LOCATION_PREFIX, CATEGORY, SINGLE_DATE}
+
+    public static EventFilter none() {
+        return new EventFilter(Type.NONE, null, null);
+    }
+
+    public static EventFilter locationPrefix(String prefix) {
+        return new EventFilter(Type.LOCATION_PREFIX, prefix, null);
+    }
+
+    public static EventFilter category(String category) {
+        return new EventFilter(Type.CATEGORY, category, null);
+    }
+
+    public static EventFilter singleDate(Calendar day) {
+        return new EventFilter(Type.SINGLE_DATE, null, day);
+    }
+}

--- a/app/src/main/java/com/example/ticketreservationapp/EventQueryBuilder.java
+++ b/app/src/main/java/com/example/ticketreservationapp/EventQueryBuilder.java
@@ -14,40 +14,32 @@ public final class EventQueryBuilder {
         return eventsRef.orderBy("date", Query.Direction.ASCENDING);
     }
 
-    public static Query build(CollectionReference eventsRef, EventFilter filter) {
+    // for unit-tests
+    static EventQuerySpec toSpec(EventFilter filter) {
         if (filter == null || filter.type() == EventFilter.Type.NONE) {
-            return baseQuery(eventsRef);
+            return EventQuerySpec.none();
         }
 
-        switch (filter.type()) {
-            case LOCATION_PREFIX: {
-                final String raw = filter.text();
-                final String prefix = (raw == null ? "" : raw.trim())
-                        .toLowerCase(Locale.getDefault());
-
-                if (prefix.isEmpty()) return baseQuery(eventsRef);
-
-                return eventsRef
-                        .orderBy("locationLower")
-                        .startAt(prefix)
-                        .endAt(prefix + "\uf8ff");
+        return switch (filter.type()) {
+            case LOCATION_PREFIX -> {
+                String raw = filter.text();
+                String prefix = (raw == null ? "" : raw.trim()).toLowerCase(Locale.getDefault());
+                yield prefix.isEmpty()
+                        ? EventQuerySpec.none()
+                        : new EventQuerySpec(EventQuerySpec.Type.LOCATION_PREFIX, prefix, null, null);
             }
 
-            case CATEGORY: {
-                final String raw = filter.text();
-                final String cat = (raw == null ? "" : raw.trim())
-                        .toUpperCase(Locale.getDefault());
-
-                if (cat.isEmpty()) return baseQuery(eventsRef);
-
-                return eventsRef
-                        .whereEqualTo("category", cat)
-                        .orderBy("date", Query.Direction.ASCENDING);
+            case CATEGORY -> {
+                String raw = filter.text();
+                String cat = (raw == null ? "" : raw.trim()).toUpperCase(Locale.getDefault());
+                yield cat.isEmpty()
+                        ? EventQuerySpec.none()
+                        : new EventQuerySpec(EventQuerySpec.Type.CATEGORY, cat, null, null);
             }
 
-            case SINGLE_DATE: {
+            case SINGLE_DATE -> {
                 Calendar selectedDay = filter.day();
-                if (selectedDay == null) return baseQuery(eventsRef);
+                if (selectedDay == null) yield EventQuerySpec.none();
 
                 Calendar start = (Calendar) selectedDay.clone();
                 start.set(Calendar.HOUR_OF_DAY, 0);
@@ -61,8 +53,43 @@ public final class EventQueryBuilder {
                 end.set(Calendar.SECOND, 59);
                 end.set(Calendar.MILLISECOND, 999);
 
-                Timestamp startTs = new Timestamp(start.getTime());
-                Timestamp endTs = new Timestamp(end.getTime());
+                yield new EventQuerySpec(
+                        EventQuerySpec.Type.SINGLE_DATE,
+                        "",
+                        start.getTime(),
+                        end.getTime()
+                );
+            }
+
+            default -> EventQuerySpec.none();
+        };
+    }
+
+    // data logic
+    public static Query build(CollectionReference eventsRef, EventFilter filter) {
+        EventQuerySpec spec = toSpec(filter);
+
+        if (spec.type() == EventQuerySpec.Type.NONE) {
+            return baseQuery(eventsRef);
+        }
+
+        switch (spec.type()) {
+            case LOCATION_PREFIX: {
+                String prefix = spec.normalizedText();
+                return eventsRef
+                        .orderBy("locationLower")
+                        .startAt(prefix)
+                        .endAt(prefix + "\uf8ff");
+            }
+
+            case CATEGORY:
+                return eventsRef
+                        .whereEqualTo("category", spec.normalizedText())
+                        .orderBy("date", Query.Direction.ASCENDING);
+
+            case SINGLE_DATE: {
+                Timestamp startTs = new Timestamp(spec.startInclusive());
+                Timestamp endTs = new Timestamp(spec.endInclusive());
 
                 return eventsRef
                         .whereGreaterThanOrEqualTo("date", startTs)

--- a/app/src/main/java/com/example/ticketreservationapp/EventQueryBuilder.java
+++ b/app/src/main/java/com/example/ticketreservationapp/EventQueryBuilder.java
@@ -1,0 +1,77 @@
+package com.example.ticketreservationapp;
+
+import com.google.firebase.Timestamp;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.Query;
+
+import java.util.Calendar;
+import java.util.Locale;
+
+public final class EventQueryBuilder {
+    private EventQueryBuilder() {}
+
+    private static Query baseQuery(CollectionReference eventsRef) {
+        return eventsRef.orderBy("date", Query.Direction.ASCENDING);
+    }
+
+    public static Query build(CollectionReference eventsRef, EventFilter filter) {
+        if (filter == null || filter.type() == EventFilter.Type.NONE) {
+            return baseQuery(eventsRef);
+        }
+
+        switch (filter.type()) {
+            case LOCATION_PREFIX: {
+                final String raw = filter.text();
+                final String prefix = (raw == null ? "" : raw.trim())
+                        .toLowerCase(Locale.getDefault());
+
+                if (prefix.isEmpty()) return baseQuery(eventsRef);
+
+                return eventsRef
+                        .orderBy("locationLower")
+                        .startAt(prefix)
+                        .endAt(prefix + "\uf8ff");
+            }
+
+            case CATEGORY: {
+                final String raw = filter.text();
+                final String cat = (raw == null ? "" : raw.trim())
+                        .toUpperCase(Locale.getDefault());
+
+                if (cat.isEmpty()) return baseQuery(eventsRef);
+
+                return eventsRef
+                        .whereEqualTo("category", cat)
+                        .orderBy("date", Query.Direction.ASCENDING);
+            }
+
+            case SINGLE_DATE: {
+                Calendar selectedDay = filter.day();
+                if (selectedDay == null) return baseQuery(eventsRef);
+
+                Calendar start = (Calendar) selectedDay.clone();
+                start.set(Calendar.HOUR_OF_DAY, 0);
+                start.set(Calendar.MINUTE, 0);
+                start.set(Calendar.SECOND, 0);
+                start.set(Calendar.MILLISECOND, 0);
+
+                Calendar end = (Calendar) selectedDay.clone();
+                end.set(Calendar.HOUR_OF_DAY, 23);
+                end.set(Calendar.MINUTE, 59);
+                end.set(Calendar.SECOND, 59);
+                end.set(Calendar.MILLISECOND, 999);
+
+                Timestamp startTs = new Timestamp(start.getTime());
+                Timestamp endTs = new Timestamp(end.getTime());
+
+                return eventsRef
+                        .whereGreaterThanOrEqualTo("date", startTs)
+                        .whereLessThanOrEqualTo("date", endTs)
+                        .orderBy("date", Query.Direction.ASCENDING);
+            }
+
+            default:
+                return baseQuery(eventsRef);
+        }
+    }
+}

--- a/app/src/main/java/com/example/ticketreservationapp/EventQuerySpec.java
+++ b/app/src/main/java/com/example/ticketreservationapp/EventQuerySpec.java
@@ -1,0 +1,22 @@
+package com.example.ticketreservationapp;
+
+import java.util.Date;
+
+public record EventQuerySpec(
+        Type type,
+        String normalizedText,
+        Date startInclusive,
+        Date endInclusive
+) {
+    public enum Type {
+        NONE,
+        LOCATION_PREFIX,
+        CATEGORY,
+        SINGLE_DATE
+    }
+
+    public static EventQuerySpec none() {
+        return new EventQuerySpec(Type.NONE, "", null, null);
+    }
+
+}

--- a/app/src/main/java/com/example/ticketreservationapp/MainActivity.java
+++ b/app/src/main/java/com/example/ticketreservationapp/MainActivity.java
@@ -29,7 +29,6 @@ import com.google.firebase.firestore.Query;
 
 import java.util.Calendar;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 
 public class MainActivity extends AppCompatActivity {
@@ -80,8 +79,7 @@ public class MainActivity extends AppCompatActivity {
         Button btnFilter = findViewById(R.id.btnFilter);
         btnFilter.setOnClickListener(v -> showFilterDialog());
         Button btnClearFilters = findViewById(R.id.btnClearFilters);
-        btnClearFilters.setOnClickListener(v -> showAllEvents());
-    }
+        btnClearFilters.setOnClickListener(v -> applyFilter(EventFilter.none()));    }
 
     @Override
     protected void onStart() {
@@ -346,6 +344,11 @@ public class MainActivity extends AppCompatActivity {
         });
     }
 
+    private void applyFilter(EventFilter filter) {
+        Query q = EventQueryBuilder.build(eventsRef, filter);
+        bindEventsAdapter(q);
+    }
+
     private void bindEventsAdapter(Query query) {
         FirestoreRecyclerOptions<Event> options =
                 new FirestoreRecyclerOptions.Builder<Event>()
@@ -359,66 +362,6 @@ public class MainActivity extends AppCompatActivity {
         eventAdapter = new EventAdapter(options, this::reserveTicket);
         rvEvents.setAdapter(eventAdapter);
         eventAdapter.startListening();
-    }
-
-    private void showAllEvents() {
-        Query q = eventsRef.orderBy("date", Query.Direction.ASCENDING);
-        bindEventsAdapter(q);
-    }
-
-    private void filterByLocationPrefix(String userInput) {
-        String prefix = userInput.trim().toLowerCase(Locale.getDefault());
-
-        if (prefix.isEmpty()) {
-            showAllEvents();
-            return;
-        }
-
-        Query q = eventsRef
-                .orderBy("locationLower")
-                .startAt(prefix)
-                .endAt(prefix + "\uf8ff");
-
-        bindEventsAdapter(q);
-    }
-
-    private void filterByCategory(String userInput) {
-        String category = userInput.trim().toUpperCase(Locale.getDefault());
-
-        if (category.isEmpty()) {
-            showAllEvents();
-            return;
-        }
-
-        Query q = eventsRef
-                .whereEqualTo("category", category)
-                .orderBy("date", Query.Direction.ASCENDING);
-
-        bindEventsAdapter(q);
-    }
-
-    private void filterBySingleDate(Calendar selectedDay) {
-        Calendar start = (Calendar) selectedDay.clone();
-        start.set(Calendar.HOUR_OF_DAY, 0);
-        start.set(Calendar.MINUTE, 0);
-        start.set(Calendar.SECOND, 0);
-        start.set(Calendar.MILLISECOND, 0);
-
-        Calendar end = (Calendar) selectedDay.clone();
-        end.set(Calendar.HOUR_OF_DAY, 23);
-        end.set(Calendar.MINUTE, 59);
-        end.set(Calendar.SECOND, 59);
-        end.set(Calendar.MILLISECOND, 999);
-
-        com.google.firebase.Timestamp startTs = new com.google.firebase.Timestamp(start.getTime());
-        com.google.firebase.Timestamp endTs = new com.google.firebase.Timestamp(end.getTime());
-
-        Query q = eventsRef
-                .whereGreaterThanOrEqualTo("date", startTs)
-                .whereLessThanOrEqualTo("date", endTs)
-                .orderBy("date", Query.Direction.ASCENDING);
-
-        bindEventsAdapter(q);
     }
 
     private void showFilterDialog() {
@@ -441,25 +384,20 @@ public class MainActivity extends AppCompatActivity {
                         case 2:
                             showDatePickerDialog();
                             break;
-                        case 3:
-                            showAllEvents();
-                            break;
                     }
                 })
                 .show();
     }
-
     private void showLocationInputDialog() {
         final com.google.android.material.textfield.TextInputEditText input =
                 new com.google.android.material.textfield.TextInputEditText(this);
-        input.setHint("Type location prefix (e.g., Cir)");
 
         new MaterialAlertDialogBuilder(this)
                 .setTitle("Search by Location")
                 .setView(input)
                 .setPositiveButton("Search", (d, w) -> {
                     String text = input.getText() == null ? "" : input.getText().toString();
-                    filterByLocationPrefix(text);
+                    applyFilter(EventFilter.locationPrefix(text));
                 })
                 .setNegativeButton(android.R.string.cancel, null)
                 .show();
@@ -468,14 +406,13 @@ public class MainActivity extends AppCompatActivity {
     private void showCategoryInputDialog() {
         final com.google.android.material.textfield.TextInputEditText input =
                 new com.google.android.material.textfield.TextInputEditText(this);
-        input.setHint("Type category (e.g., SPORTS)");
 
         new MaterialAlertDialogBuilder(this)
                 .setTitle("Filter by Category")
                 .setView(input)
                 .setPositiveButton("Apply", (d, w) -> {
                     String text = input.getText() == null ? "" : input.getText().toString();
-                    filterByCategory(text);
+                    applyFilter(EventFilter.category(text));
                 })
                 .setNegativeButton(android.R.string.cancel, null)
                 .show();
@@ -489,12 +426,11 @@ public class MainActivity extends AppCompatActivity {
                 (view, year, month, dayOfMonth) -> {
                     Calendar selected = Calendar.getInstance();
                     selected.set(year, month, dayOfMonth);
-                    filterBySingleDate(selected);
+                    applyFilter(EventFilter.singleDate(selected));
                 },
                 cal.get(Calendar.YEAR),
                 cal.get(Calendar.MONTH),
                 cal.get(Calendar.DAY_OF_MONTH)
         ).show();
     }
-
 }

--- a/app/src/main/java/com/example/ticketreservationapp/MainActivity.java
+++ b/app/src/main/java/com/example/ticketreservationapp/MainActivity.java
@@ -27,7 +27,9 @@ import com.google.firebase.firestore.FieldValue;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.Query;
 
+import java.util.Calendar;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 public class MainActivity extends AppCompatActivity {
@@ -74,6 +76,11 @@ public class MainActivity extends AppCompatActivity {
         initAuth();
         initEventsRecyclerView();
         initReservationsRecyclerView();
+
+        Button btnFilter = findViewById(R.id.btnFilter);
+        btnFilter.setOnClickListener(v -> showFilterDialog());
+        Button btnClearFilters = findViewById(R.id.btnClearFilters);
+        btnClearFilters.setOnClickListener(v -> showAllEvents());
     }
 
     @Override
@@ -337,6 +344,157 @@ public class MainActivity extends AppCompatActivity {
             }
             Toast.makeText(this, message, Toast.LENGTH_LONG).show();
         });
+    }
+
+    private void bindEventsAdapter(Query query) {
+        FirestoreRecyclerOptions<Event> options =
+                new FirestoreRecyclerOptions.Builder<Event>()
+                        .setQuery(query, Event.class)
+                        .build();
+
+        if (eventAdapter != null) {
+            eventAdapter.stopListening();
+        }
+
+        eventAdapter = new EventAdapter(options, this::reserveTicket);
+        rvEvents.setAdapter(eventAdapter);
+        eventAdapter.startListening();
+    }
+
+    private void showAllEvents() {
+        Query q = eventsRef.orderBy("date", Query.Direction.ASCENDING);
+        bindEventsAdapter(q);
+    }
+
+    private void filterByLocationPrefix(String userInput) {
+        String prefix = userInput.trim().toLowerCase(Locale.getDefault());
+
+        if (prefix.isEmpty()) {
+            showAllEvents();
+            return;
+        }
+
+        Query q = eventsRef
+                .orderBy("locationLower")
+                .startAt(prefix)
+                .endAt(prefix + "\uf8ff");
+
+        bindEventsAdapter(q);
+    }
+
+    private void filterByCategory(String userInput) {
+        String category = userInput.trim().toUpperCase(Locale.getDefault());
+
+        if (category.isEmpty()) {
+            showAllEvents();
+            return;
+        }
+
+        Query q = eventsRef
+                .whereEqualTo("category", category)
+                .orderBy("date", Query.Direction.ASCENDING);
+
+        bindEventsAdapter(q);
+    }
+
+    private void filterBySingleDate(Calendar selectedDay) {
+        Calendar start = (Calendar) selectedDay.clone();
+        start.set(Calendar.HOUR_OF_DAY, 0);
+        start.set(Calendar.MINUTE, 0);
+        start.set(Calendar.SECOND, 0);
+        start.set(Calendar.MILLISECOND, 0);
+
+        Calendar end = (Calendar) selectedDay.clone();
+        end.set(Calendar.HOUR_OF_DAY, 23);
+        end.set(Calendar.MINUTE, 59);
+        end.set(Calendar.SECOND, 59);
+        end.set(Calendar.MILLISECOND, 999);
+
+        com.google.firebase.Timestamp startTs = new com.google.firebase.Timestamp(start.getTime());
+        com.google.firebase.Timestamp endTs = new com.google.firebase.Timestamp(end.getTime());
+
+        Query q = eventsRef
+                .whereGreaterThanOrEqualTo("date", startTs)
+                .whereLessThanOrEqualTo("date", endTs)
+                .orderBy("date", Query.Direction.ASCENDING);
+
+        bindEventsAdapter(q);
+    }
+
+    private void showFilterDialog() {
+        String[] options = new String[] {
+                "Search by Location",
+                "Filter by Category",
+                "Filter by Date",
+        };
+
+        new MaterialAlertDialogBuilder(this)
+                .setTitle("Filter Events")
+                .setItems(options, (dialog, which) -> {
+                    switch (which) {
+                        case 0:
+                            showLocationInputDialog();
+                            break;
+                        case 1:
+                            showCategoryInputDialog();
+                            break;
+                        case 2:
+                            showDatePickerDialog();
+                            break;
+                        case 3:
+                            showAllEvents();
+                            break;
+                    }
+                })
+                .show();
+    }
+
+    private void showLocationInputDialog() {
+        final com.google.android.material.textfield.TextInputEditText input =
+                new com.google.android.material.textfield.TextInputEditText(this);
+        input.setHint("Type location prefix (e.g., Cir)");
+
+        new MaterialAlertDialogBuilder(this)
+                .setTitle("Search by Location")
+                .setView(input)
+                .setPositiveButton("Search", (d, w) -> {
+                    String text = input.getText() == null ? "" : input.getText().toString();
+                    filterByLocationPrefix(text);
+                })
+                .setNegativeButton(android.R.string.cancel, null)
+                .show();
+    }
+
+    private void showCategoryInputDialog() {
+        final com.google.android.material.textfield.TextInputEditText input =
+                new com.google.android.material.textfield.TextInputEditText(this);
+        input.setHint("Type category (e.g., SPORTS)");
+
+        new MaterialAlertDialogBuilder(this)
+                .setTitle("Filter by Category")
+                .setView(input)
+                .setPositiveButton("Apply", (d, w) -> {
+                    String text = input.getText() == null ? "" : input.getText().toString();
+                    filterByCategory(text);
+                })
+                .setNegativeButton(android.R.string.cancel, null)
+                .show();
+    }
+
+    private void showDatePickerDialog() {
+        Calendar cal = Calendar.getInstance();
+
+        new android.app.DatePickerDialog(
+                this,
+                (view, year, month, dayOfMonth) -> {
+                    Calendar selected = Calendar.getInstance();
+                    selected.set(year, month, dayOfMonth);
+                    filterBySingleDate(selected);
+                },
+                cal.get(Calendar.YEAR),
+                cal.get(Calendar.MONTH),
+                cal.get(Calendar.DAY_OF_MONTH)
+        ).show();
     }
 
 }

--- a/app/src/main/java/com/example/ticketreservationapp/MainActivity.java
+++ b/app/src/main/java/com/example/ticketreservationapp/MainActivity.java
@@ -49,7 +49,9 @@ public class MainActivity extends AppCompatActivity {
     private MaterialToolbar toolbar;
     private TabLayout reservationsTabs;
     private int selectedReservationsFilterTab = 0;
-
+    private TextView tvNoMatchingResultsFromFilter;
+    private boolean filterApplied = false;
+    private final EventAdapter.EmptyStateListener eventsEmptyListener = empty -> refreshEventsEmptyUi();
     FirebaseAuth auth;
 
     FirebaseAuth.AuthStateListener authStateListener = new FirebaseAuth.AuthStateListener() {
@@ -72,6 +74,8 @@ public class MainActivity extends AppCompatActivity {
         toolbar = findViewById(R.id.mainToolbar);
         reservationsTabs = findViewById(R.id.tabsReservations);
 
+        tvNoMatchingResultsFromFilter = findViewById(R.id.tvNoMatchingResultsFromFilter);
+
         initAuth();
         initEventsRecyclerView();
         initReservationsRecyclerView();
@@ -79,7 +83,8 @@ public class MainActivity extends AppCompatActivity {
         Button btnFilter = findViewById(R.id.btnFilter);
         btnFilter.setOnClickListener(v -> showFilterDialog());
         Button btnClearFilters = findViewById(R.id.btnClearFilters);
-        btnClearFilters.setOnClickListener(v -> applyFilter(EventFilter.none()));    }
+        btnClearFilters.setOnClickListener(v -> applyFilter(EventFilter.none()));
+    }
 
     @Override
     protected void onStart() {
@@ -157,7 +162,7 @@ public class MainActivity extends AppCompatActivity {
                 .setQuery(query, Event.class)
                 .build();
 
-        eventAdapter = new EventAdapter(options, this::reserveTicket);
+        eventAdapter = new EventAdapter(options, this::reserveTicket, eventsEmptyListener);
 
         rvEvents.setLayoutManager(new LinearLayoutManager(this));
         rvEvents.setAdapter(eventAdapter);
@@ -223,13 +228,23 @@ public class MainActivity extends AppCompatActivity {
 
         updateReservationsEmptyState(reservationAdapter.getItemCount() == 0);
     }
+    private void refreshEventsEmptyUi() {
+        if (tvNoMatchingResultsFromFilter == null) return;
 
+        boolean isEventsVisible = rvEvents.getVisibility() == View.VISIBLE;
+        boolean isEmpty = (eventAdapter == null) || eventAdapter.getItemCount() == 0;
+
+        tvNoMatchingResultsFromFilter.setVisibility(isEventsVisible && filterApplied && isEmpty ? View.VISIBLE : View.GONE
+        );
+    }
     private void showEventsTab() {
         rvEvents.setVisibility(View.VISIBLE);
         reservationsTabs.setVisibility(View.GONE);
         rvReservations.setVisibility(View.GONE);
         tvEmptyReservations.setVisibility(View.GONE);
         toolbar.setTitle("Book Events");
+
+        refreshEventsEmptyUi();
     }
 
     private void showReservationsTab() {
@@ -240,6 +255,10 @@ public class MainActivity extends AppCompatActivity {
 
         if (reservationAdapter == null) {
             initReservationsRecyclerView();
+        }
+
+        if (tvNoMatchingResultsFromFilter != null) {
+            tvNoMatchingResultsFromFilter.setVisibility(View.GONE);
         }
 
         boolean isEmpty = reservationAdapter == null || reservationAdapter.getItemCount() == 0;
@@ -345,6 +364,8 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void applyFilter(EventFilter filter) {
+        filterApplied = (filter != null && filter.type() != EventFilter.Type.NONE);
+        //android.util.Log.d("MainActivity", "applyFilter type=" + (filter == null ? "null" : filter.type()) + " filterApplied=" + filterApplied);
         Query q = EventQueryBuilder.build(eventsRef, filter);
         bindEventsAdapter(q);
     }
@@ -359,9 +380,11 @@ public class MainActivity extends AppCompatActivity {
             eventAdapter.stopListening();
         }
 
-        eventAdapter = new EventAdapter(options, this::reserveTicket);
+        eventAdapter = new EventAdapter(options, this::reserveTicket, eventsEmptyListener);
         rvEvents.setAdapter(eventAdapter);
         eventAdapter.startListening();
+
+        refreshEventsEmptyUi();
     }
 
     private void showFilterDialog() {
@@ -397,6 +420,7 @@ public class MainActivity extends AppCompatActivity {
                 .setView(input)
                 .setPositiveButton("Search", (d, w) -> {
                     String text = input.getText() == null ? "" : input.getText().toString();
+                    text = text.trim();
                     applyFilter(EventFilter.locationPrefix(text));
                 })
                 .setNegativeButton(android.R.string.cancel, null)
@@ -412,6 +436,7 @@ public class MainActivity extends AppCompatActivity {
                 .setView(input)
                 .setPositiveButton("Apply", (d, w) -> {
                     String text = input.getText() == null ? "" : input.getText().toString();
+                    text = text.trim();
                     applyFilter(EventFilter.category(text));
                 })
                 .setNegativeButton(android.R.string.cancel, null)

--- a/app/src/main/res/drawable/ic_filter_list.xml
+++ b/app/src/main/res/drawable/ic_filter_list.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M10,18h4v-2h-4v2zM3,6v2h18L21,6L3,6zM6,13h12v-2L6,11v2z"/>
+    
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -26,8 +26,8 @@
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/logout"
                 style="@style/Widget.MaterialComponents.Button.TextButton"
-                android:layout_width="40dp"
-                android:layout_height="40dp"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
                 android:layout_gravity="end"
                 android:layout_marginEnd="10dp"
                 android:contentDescription="@string/logout_button"
@@ -69,20 +69,23 @@
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/btnFilter"
-                style="@style/Widget.MaterialComponents.Button.TextButton"
-                android:layout_width="40dp"
-                android:layout_height="40dp"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_weight="1"
+                android:minHeight="48dp"
                 android:contentDescription="@string/filter_events"
-                android:text=""
+                android:text="@string/filter_results"
                 app:icon="@drawable/ic_filter_list"
                 app:iconTint="@color/purple_700" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/btnClearFilters"
                 style="@style/Widget.MaterialComponents.Button.OutlinedButton"
-                android:layout_width="0dp"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
+                android:layout_marginEnd="8dp"
                 android:text="@string/clear_filters" />
         </LinearLayout>
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -49,14 +49,52 @@
             app:tabTextColor="#757575" />
     </com.google.android.material.appbar.AppBarLayout>
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/rvEvents"
+    <LinearLayout
+        android:id="@+id/eventsContainer"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:clipToPadding="false"
+        android:orientation="vertical"
         android:paddingBottom="88dp"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior"
-        tools:listitem="@layout/item_event" />
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingStart="12dp"
+            android:paddingEnd="12dp"
+            android:paddingTop="12dp"
+            android:paddingBottom="8dp">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnFilter"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:contentDescription="@string/filter_events"
+                android:text=""
+                app:icon="@drawable/ic_filter_list"
+                app:iconTint="@color/purple_700" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnClearFilters"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/clear_filters" />
+        </LinearLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rvEvents"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipToPadding="false"
+            android:paddingBottom="88dp"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior"
+            tools:listitem="@layout/item_event" />
+    </LinearLayout>
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rvReservations"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -26,8 +26,8 @@
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/logout"
                 style="@style/Widget.MaterialComponents.Button.TextButton"
-                android:layout_width="48dp"
-                android:layout_height="48dp"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
                 android:layout_gravity="end"
                 android:layout_marginEnd="10dp"
                 android:contentDescription="@string/logout_button"
@@ -64,7 +64,7 @@
             android:gravity="center_vertical"
             android:paddingStart="12dp"
             android:paddingEnd="12dp"
-            android:paddingTop="12dp"
+            android:paddingTop="10dp"
             android:paddingBottom="8dp">
 
             <com.google.android.material.button.MaterialButton

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -121,6 +121,19 @@
         android:visibility="gone"
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
+    <TextView
+        android:id="@+id/tvNoMatchingResultsFromFilter"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:text="@string/no_events_match_the_selected_filter_clear_filter_and_try_again"
+        android:textColor="#757575"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        android:visibility="gone"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottomNav"
         android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,4 +27,6 @@
     <string name="reservation_cancelled_success">Reservation cancelled. %1$d ticket(s) released.</string>
     <string name="reservation_already_cancelled">This reservation is already cancelled.</string>
     <string name="cancel_reservation_failed">Unable to cancel reservation right now. Please try again.</string>
+    <string name="filter_events">Filter events</string>
+    <string name="clear_filters">Clear Filter</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,4 +29,5 @@
     <string name="cancel_reservation_failed">Unable to cancel reservation right now. Please try again.</string>
     <string name="filter_events">Filter events</string>
     <string name="clear_filters">Clear Filter</string>
+    <string name="filter_results">filter results</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,4 +30,5 @@
     <string name="filter_events">Filter events</string>
     <string name="clear_filters">Clear Filter</string>
     <string name="filter_results">filter results</string>
+    <string name="no_events_match_the_selected_filter_clear_filter_and_try_again">No events match the selected filter. Clear filter and try again.</string>
 </resources>

--- a/app/src/test/java/com/example/ticketreservationapp/EventAdapterTest.java
+++ b/app/src/test/java/com/example/ticketreservationapp/EventAdapterTest.java
@@ -229,4 +229,18 @@ public class EventAdapterTest {
         assertTrue(activity.editCalled);
         assertTrue(activity.deleteCalled);
     }
+    @Test
+    public void onDataChanged_notifiesEmptyStateListener_whenItsEmpty() {
+        AtomicReference<Boolean> empty = new AtomicReference<>(null);
+
+        EventAdapter adapter = new EventAdapter(
+                mockOptions(),
+                (event, quantity) -> {},
+                empty::set
+        );
+
+        adapter.onDataChanged();
+
+        assertEquals(Boolean.TRUE, empty.get());
+    }
 }

--- a/app/src/test/java/com/example/ticketreservationapp/EventQueryBuilderSpecTest.java
+++ b/app/src/test/java/com/example/ticketreservationapp/EventQueryBuilderSpecTest.java
@@ -1,0 +1,104 @@
+package com.example.ticketreservationapp;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+
+public class EventQueryBuilderSpecTest {
+
+    @Test
+    public void toSpec_null_returnsNone() {
+        assertEquals(EventQuerySpec.Type.NONE, EventQueryBuilder.toSpec(null).type());
+    }
+
+    @Test
+    public void toSpec_none_returnsNone() {
+        assertEquals(EventQuerySpec.Type.NONE, EventQueryBuilder.toSpec(EventFilter.none()).type());
+    }
+
+    @Test
+    public void toSpec_locationPrefix_nullText_becomesNone() {
+        EventFilter f = new EventFilter(EventFilter.Type.LOCATION_PREFIX, null, null);
+        assertEquals(EventQuerySpec.Type.NONE, EventQueryBuilder.toSpec(f).type());
+    }
+
+    @Test
+    public void toSpec_locationPrefix_blank_becomesNone() {
+        assertEquals(EventQuerySpec.Type.NONE,
+                EventQueryBuilder.toSpec(EventFilter.locationPrefix("   ")).type());
+    }
+
+    @Test
+    public void toSpec_locationPrefix_trimsAndLowercases() {
+        EventQuerySpec spec = EventQueryBuilder.toSpec(EventFilter.locationPrefix("  Ray "));
+        assertEquals(EventQuerySpec.Type.LOCATION_PREFIX, spec.type());
+        assertEquals("ray", spec.normalizedText());
+    }
+
+    @Test
+    public void toSpec_category_nullText_becomesNone() {
+        EventFilter f = new EventFilter(EventFilter.Type.CATEGORY, null, null);
+        assertEquals(EventQuerySpec.Type.NONE, EventQueryBuilder.toSpec(f).type());
+    }
+
+    @Test
+    public void toSpec_category_blank_becomesNone() {
+        assertEquals(EventQuerySpec.Type.NONE,
+                EventQueryBuilder.toSpec(EventFilter.category("")).type());
+    }
+
+    @Test
+    public void toSpec_category_trimsAndUppercases() {
+        EventQuerySpec spec = EventQueryBuilder.toSpec(EventFilter.category(" sports    "));
+        assertEquals(EventQuerySpec.Type.CATEGORY, spec.type());
+        assertEquals("SPORTS", spec.normalizedText());
+    }
+
+    @Test
+    public void toSpec_category_mixedCase_normalizesToUpper() {
+        EventQuerySpec spec = EventQueryBuilder.toSpec(EventFilter.category("sPoRtS"));
+        assertEquals("SPORTS", spec.normalizedText());
+    }
+
+    @Test
+    public void toSpec_singleDate_null_becomesNone() {
+        assertEquals(EventQuerySpec.Type.NONE,
+                EventQueryBuilder.toSpec(EventFilter.singleDate(null)).type());
+    }
+
+    @Test
+    public void toSpec_singleDate_createsFullDayRange() {
+        TimeZone tz = TimeZone.getTimeZone("UTC");
+
+        Calendar c = Calendar.getInstance(tz);
+        c.set(2026, Calendar.APRIL, 7, 15, 30, 10);
+        c.set(Calendar.MILLISECOND, 123);
+
+        EventQuerySpec spec = EventQueryBuilder.toSpec(EventFilter.singleDate(c));
+        assertEquals(EventQuerySpec.Type.SINGLE_DATE, spec.type());
+
+        Date start = spec.startInclusive();
+        Date end = spec.endInclusive();
+        assertNotNull(start);
+        assertNotNull(end);
+        assertFalse(start.after(end));
+
+        Calendar startCal = Calendar.getInstance(tz);
+        startCal.setTime(start);
+        assertEquals(0, startCal.get(Calendar.HOUR_OF_DAY));
+        assertEquals(0, startCal.get(Calendar.MINUTE));
+        assertEquals(0, startCal.get(Calendar.SECOND));
+        assertEquals(0, startCal.get(Calendar.MILLISECOND));
+
+        Calendar endCal = Calendar.getInstance(tz);
+        endCal.setTime(end);
+        assertEquals(23, endCal.get(Calendar.HOUR_OF_DAY));
+        assertEquals(59, endCal.get(Calendar.MINUTE));
+        assertEquals(59, endCal.get(Calendar.SECOND));
+        assertEquals(999, endCal.get(Calendar.MILLISECOND));
+    }
+}


### PR DESCRIPTION
User can now filter events by category, date, and location.

To note:
- Category needs to be written to match spelling.
- Location uses prefix search to avoid having to write the location in full.
- Ive added a field in events to hold the location in small caps to be be able filter. All existing events have been updated to follow the convention and future events should follow as I've added it on the admin page.
- Added specification-based unit tests for EventQueryBuilder.toSpec(...) to validate filter. Handling null inputs, trimming and lower-case check for location, and that the date filter is for a single entire day.
- Added an Android instrumented smoke test for EventQueryBuilder.build(...) to verify that Firebase is initialized correctly and that building Firestore Query objects succeeds for each filter type in an Android runtime. Does not check for correctness just that it is not null

closes #3 