### PR TITLE
Add unit tests (EventQueryBuilder and MainActivity)

### DIFF
--- a/app/src/main/java/com/example/ticketreservationapp/MainActivity.java
+++ b/app/src/main/java/com/example/ticketreservationapp/MainActivity.java
@@ -38,9 +38,23 @@ public class MainActivity extends AppCompatActivity {
     private static final String STATUS_CONFIRMED = "confirmed";
     private static final String STATUS_CANCELLED = "cancelled";
 
-    private final FirebaseFirestore db = FirebaseFirestore.getInstance();
-    private final CollectionReference eventsRef = db.collection("events");
-    private final CollectionReference reservationsRef = db.collection("reservations");
+    // to be able to override in tests
+    protected FirebaseAuth provideAuth() {
+        return FirebaseAuth.getInstance();
+    }
+    protected FirebaseFirestore provideDb() {
+        return FirebaseFirestore.getInstance();
+    }
+    protected CollectionReference provideEventsRef(FirebaseFirestore db) {
+        return db.collection("events");
+    }
+    protected CollectionReference provideReservationsRef(FirebaseFirestore db) {
+        return db.collection("reservations");
+    }
+    private FirebaseAuth auth;
+    private FirebaseFirestore db;
+    private CollectionReference eventsRef;
+    private CollectionReference reservationsRef;
     private EventAdapter eventAdapter;
     private ReservationAdapter reservationAdapter;
     private RecyclerView rvEvents;
@@ -52,8 +66,6 @@ public class MainActivity extends AppCompatActivity {
     private TextView tvNoMatchingResultsFromFilter;
     private boolean filterApplied = false;
     private final EventAdapter.EmptyStateListener eventsEmptyListener = empty -> refreshEventsEmptyUi();
-    FirebaseAuth auth;
-
     FirebaseAuth.AuthStateListener authStateListener = new FirebaseAuth.AuthStateListener() {
         @Override
         public void onAuthStateChanged(@NonNull FirebaseAuth firebaseAuth) {
@@ -67,6 +79,10 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         EdgeToEdge.enable(this);
         setContentView(R.layout.activity_main);
+        auth = provideAuth();
+        db = provideDb();
+        eventsRef = provideEventsRef(db);
+        reservationsRef = provideReservationsRef(db);
 
         rvEvents = findViewById(R.id.rvEvents);
         rvReservations = findViewById(R.id.rvReservations);
@@ -134,7 +150,6 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void initAuth() {
-        auth = FirebaseAuth.getInstance();
         Button logout = findViewById(R.id.logout);
         BottomNavigationView bottomNavigation = findViewById(R.id.bottomNav);
 

--- a/app/src/test/java/com/example/ticketreservationapp/EventQueryBuilderSpecTest.java
+++ b/app/src/test/java/com/example/ticketreservationapp/EventQueryBuilderSpecTest.java
@@ -1,11 +1,18 @@
 package com.example.ticketreservationapp;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import com.google.firebase.Timestamp;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.Query;
 
 import org.junit.Test;
 
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Locale;
 import java.util.TimeZone;
 
 public class EventQueryBuilderSpecTest {
@@ -100,5 +107,75 @@ public class EventQueryBuilderSpecTest {
         assertEquals(59, endCal.get(Calendar.MINUTE));
         assertEquals(59, endCal.get(Calendar.SECOND));
         assertEquals(999, endCal.get(Calendar.MILLISECOND));
+    }
+
+    @Test
+    public void build_none_callsBaseQuery_orderByDate() {
+        CollectionReference eventsRef = mock(CollectionReference.class);
+        Query base = mock(Query.class);
+
+        when(eventsRef.orderBy("date", Query.Direction.ASCENDING)).thenReturn(base);
+
+        Query result = EventQueryBuilder.build(eventsRef, EventFilter.none());
+
+        assertSame(base, result);
+        verify(eventsRef).orderBy("date", Query.Direction.ASCENDING);
+    }
+
+    @Test
+    public void build_locationPrefix_chainsOrderByStartAtEndAt() {
+        CollectionReference eventsRef = mock(CollectionReference.class);
+        Query ordered = mock(Query.class);
+        Query started = mock(Query.class);
+        Query ended = mock(Query.class);
+
+        when(eventsRef.orderBy("locationLower")).thenReturn(ordered);
+        when(ordered.startAt("ny")).thenReturn(started);
+        when(started.endAt("ny" + "\uf8ff")).thenReturn(ended);
+
+        Query result = EventQueryBuilder.build(eventsRef, EventFilter.locationPrefix(" NY "));
+
+        assertSame(ended, result);
+        verify(eventsRef).orderBy("locationLower");
+        verify(ordered).startAt("ny");
+        verify(started).endAt("ny" + "\uf8ff");
+    }
+
+    @Test
+    public void build_category_callsWhereEqualTo_thenOrderByDate() {
+        CollectionReference eventsRef = mock(CollectionReference.class);
+        Query afterWhere = mock(Query.class);
+        Query afterOrder = mock(Query.class);
+
+        when(eventsRef.whereEqualTo("category", "MOVIES")).thenReturn(afterWhere);
+        when(afterWhere.orderBy("date", Query.Direction.ASCENDING)).thenReturn(afterOrder);
+
+        Query result = EventQueryBuilder.build(eventsRef, EventFilter.category("movies"));
+
+        assertSame(afterOrder, result);
+        verify(eventsRef).whereEqualTo("category", "MOVIES");
+        verify(afterWhere).orderBy("date", Query.Direction.ASCENDING);
+    }
+
+    @Test
+    public void build_singleDate_chainsDateRangeQuery() {
+        CollectionReference eventsRef = mock(CollectionReference.class);
+        Query q1 = mock(Query.class);
+        Query q2 = mock(Query.class);
+        Query q3 = mock(Query.class);
+
+        when(eventsRef.whereGreaterThanOrEqualTo(eq("date"), any(Timestamp.class))).thenReturn(q1);
+        when(q1.whereLessThanOrEqualTo(eq("date"), any(Timestamp.class))).thenReturn(q2);
+        when(q2.orderBy("date", Query.Direction.ASCENDING)).thenReturn(q3);
+
+        Calendar selected = Calendar.getInstance(Locale.CANADA);
+        selected.set(2026, Calendar.APRIL, 11, 10, 0, 0);
+
+        Query result = EventQueryBuilder.build(eventsRef, EventFilter.singleDate(selected));
+
+        assertSame(q3, result);
+        verify(eventsRef).whereGreaterThanOrEqualTo(eq("date"), any(Timestamp.class));
+        verify(q1).whereLessThanOrEqualTo(eq("date"), any(Timestamp.class));
+        verify(q2).orderBy("date", Query.Direction.ASCENDING);
     }
 }

--- a/app/src/test/java/com/example/ticketreservationapp/MainActivityTest.java
+++ b/app/src/test/java/com/example/ticketreservationapp/MainActivityTest.java
@@ -5,24 +5,38 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
 
 import android.content.Context;
+import android.os.Looper;
 import android.view.View;
 
 import androidx.recyclerview.widget.RecyclerView;
-
+import com.google.android.gms.tasks.Tasks;
+import com.google.android.material.textfield.TextInputEditText;
 import com.google.android.material.appbar.MaterialToolbar;
+import androidx.appcompat.app.AlertDialog;
+import android.widget.ListView;
+
+import org.robolectric.Shadows;
 import com.google.android.material.tabs.TabLayout;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.auth.FirebaseUser;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.DocumentReference;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.Transaction;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.After;
+import org.junit.Before;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.shadows.ShadowDialog;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowToast;
@@ -46,9 +60,34 @@ public class MainActivityTest {
         }
     }
 
+    public static class TestMainActivity extends MainActivity {
+        static FirebaseAuth AUTH;
+        static FirebaseFirestore DB;
+        static CollectionReference EVENTS_REF;
+        static CollectionReference RESERVATIONS_REF;
+
+        @Override protected FirebaseAuth provideAuth() { return AUTH; }
+        @Override protected FirebaseFirestore provideDb() { return DB; }
+        @Override protected CollectionReference provideEventsRef(FirebaseFirestore ignored) { return EVENTS_REF; }
+        @Override protected CollectionReference provideReservationsRef(FirebaseFirestore ignored) { return RESERVATIONS_REF; }
+    }
+    @Before
+    public void setUp() {
+        initFirebase();
+
+        TestMainActivity.AUTH = mock(FirebaseAuth.class);
+        TestMainActivity.DB = mock(FirebaseFirestore.class);
+        TestMainActivity.EVENTS_REF = mock(CollectionReference.class);
+        TestMainActivity.RESERVATIONS_REF = mock(CollectionReference.class);
+    }
+
+    @After
+    public void tearDown() {
+        resetTestDeps();
+    }
+
     @Test
     public void privateUiMethods_toggleTabsAndEmptyState() throws Exception {
-        initFirebase();
         MainActivity activity;
         try (ActivityController<MainActivity> controller = Robolectric.buildActivity(MainActivity.class).create()) {
             activity = controller.get();
@@ -81,7 +120,6 @@ public class MainActivityTest {
 
     @Test
     public void reserveTicket_withoutUser_showsLoginToast() throws Exception {
-        initFirebase();
         MainActivity activity;
         try (ActivityController<MainActivity> controller = Robolectric.buildActivity(MainActivity.class).create()) {
             activity = controller.get();
@@ -102,7 +140,6 @@ public class MainActivityTest {
 
     @Test
     public void onStartAndOnStop_withAdapters_callsListenerLifecycle() throws Exception {
-        initFirebase();
         MainActivity activity;
         try (ActivityController<MainActivity> controller = Robolectric.buildActivity(MainActivity.class).create()) {
             activity = controller.get();
@@ -130,7 +167,6 @@ public class MainActivityTest {
 
     @Test
     public void checkUserStatus_whenUserNull_redirectsToLogin() throws Exception {
-        initFirebase();
         MainActivity activity;
         try (ActivityController<MainActivity> controller = Robolectric.buildActivity(MainActivity.class).create()) {
             activity = controller.get();
@@ -163,5 +199,313 @@ public class MainActivityTest {
         Field field = MainActivity.class.getDeclaredField(fieldName);
         field.setAccessible(true);
         return type.cast(field.get(activity));
+    }
+    private TextInputEditText findFirstTextInputEditText(View root) {
+        if (root instanceof TextInputEditText) return (TextInputEditText) root;
+
+        if (root instanceof android.view.ViewGroup) {
+            android.view.ViewGroup vg = (android.view.ViewGroup) root;
+            for (int i = 0; i < vg.getChildCount(); i++) {
+                TextInputEditText found = findFirstTextInputEditText(vg.getChildAt(i));
+                if (found != null) return found;
+            }
+        }
+        return null;
+    }
+
+    @Test
+    public void cancelReservation_whenRunTransactionFails_showsFailedToast() throws Exception {
+        DocumentReference reservationDoc = mock(DocumentReference.class);
+        when(TestMainActivity.RESERVATIONS_REF.document("res-1")).thenReturn(reservationDoc);
+
+        when(TestMainActivity.DB.runTransaction(any(Transaction.Function.class))).thenReturn(Tasks.forException(new RuntimeException("boom")));
+
+        try (ActivityController<TestMainActivity> controller = Robolectric.buildActivity(TestMainActivity.class).create()) {
+            TestMainActivity activity = controller.get();
+
+            Reservation r = new Reservation();
+            r.setId("res-1");
+
+            ShadowToast.reset();
+            invokePrivate(activity, "cancelReservation", new Class<?>[]{Reservation.class}, r);
+            Shadows.shadowOf(Looper.getMainLooper()).idle();
+
+            assertEquals(activity.getString(R.string.cancel_reservation_failed), ShadowToast.getTextOfLatestToast());
+        }
+    }
+
+    @Test
+    public void cancelReservation_whenRunTransactionSucceeds_showsSuccessToast() throws Exception {
+        DocumentReference reservationDoc = mock(DocumentReference.class);
+        when(TestMainActivity.RESERVATIONS_REF.document("res-1")).thenReturn(reservationDoc);
+
+        when(TestMainActivity.DB.runTransaction(any(Transaction.Function.class))).thenReturn(Tasks.forResult(2));
+
+        try (ActivityController<TestMainActivity> controller = Robolectric.buildActivity(TestMainActivity.class).create()) {
+            TestMainActivity activity = controller.get();
+
+            Reservation r = new Reservation();
+            r.setId("res-1");
+
+            ShadowToast.reset();
+            invokePrivate(activity, "cancelReservation", new Class<?>[]{Reservation.class}, r);
+            Shadows.shadowOf(Looper.getMainLooper()).idle();
+
+            String expected = activity.getString(R.string.reservation_cancelled_success, 2);
+            assertEquals(expected, ShadowToast.getTextOfLatestToast());
+        }
+    }
+
+    @Test
+    public void reserveTicket_whenTransactionSucceeds_showsConfirmedToast() throws Exception {
+        when(TestMainActivity.AUTH.getCurrentUser()).thenReturn(null);
+
+        DocumentReference newReservationDoc = mock(DocumentReference.class);
+        when(TestMainActivity.RESERVATIONS_REF.document()).thenReturn(newReservationDoc);
+
+        when(TestMainActivity.DB.runTransaction(any(Transaction.Function.class))).thenReturn(Tasks.forResult(null));
+
+        try (ActivityController<TestMainActivity> controller = Robolectric.buildActivity(TestMainActivity.class).create()) {
+            TestMainActivity activity = controller.get();
+
+            FirebaseUser user = mock(FirebaseUser.class);
+            when(user.getUid()).thenReturn("user-1");
+            when(TestMainActivity.AUTH.getCurrentUser()).thenReturn(user);
+
+            Event event = new Event();
+            event.setId("event-1");
+
+            ShadowToast.reset();
+            invokePrivate(activity, "reserveTicket", new Class<?>[]{Event.class, int.class}, event, 2);
+            Shadows.shadowOf(Looper.getMainLooper()).idle();
+
+            assertEquals("2 ticket(s) booked! Reservation confirmed.", ShadowToast.getTextOfLatestToast());
+        }
+    }
+
+    @Test
+    public void reserveTicket_whenNotEnoughTickets_showsNotEnoughToast() throws Exception {
+        when(TestMainActivity.AUTH.getCurrentUser()).thenReturn(null);
+
+        DocumentReference newReservationDoc = mock(DocumentReference.class);
+        when(TestMainActivity.RESERVATIONS_REF.document()).thenReturn(newReservationDoc);
+
+        when(TestMainActivity.DB.runTransaction(any(Transaction.Function.class))).thenReturn(Tasks.forException(new IllegalStateException("Not enough tickets available for selected quantity")));
+
+        try (ActivityController<TestMainActivity> controller = Robolectric.buildActivity(TestMainActivity.class).create()) {
+            TestMainActivity activity = controller.get();
+
+            FirebaseUser user = mock(FirebaseUser.class);
+            when(user.getUid()).thenReturn("user-1");
+            when(TestMainActivity.AUTH.getCurrentUser()).thenReturn(user);
+
+            Event event = new Event();
+            event.setId("event-1");
+
+            ShadowToast.reset();
+            invokePrivate(activity, "reserveTicket", new Class<?>[]{Event.class, int.class}, event, 2);
+            Shadows.shadowOf(Looper.getMainLooper()).idle();
+
+            assertEquals("Not enough tickets available for selected quantity", ShadowToast.getTextOfLatestToast());
+        }
+    }
+    private void resetTestDeps() {
+        TestMainActivity.AUTH = null;
+        TestMainActivity.DB = null;
+        TestMainActivity.EVENTS_REF = null;
+        TestMainActivity.RESERVATIONS_REF = null;
+    }
+    @Test
+    public void showFilterDialog_clickEachOption_executesBranches() throws Exception {
+        MainActivity activity;
+        try (ActivityController<MainActivity> controller = Robolectric.buildActivity(MainActivity.class).create()) {
+            activity = controller.get();
+
+            invokePrivate(activity, "showFilterDialog");
+            AlertDialog dialog0 = (AlertDialog) ShadowDialog.getLatestDialog();
+            assertNotNull(dialog0);
+            clickDialogListItem(dialog0, 0);
+            Shadows.shadowOf(Looper.getMainLooper()).idle();
+            assertNotNull(ShadowDialog.getLatestDialog());
+
+            invokePrivate(activity, "showFilterDialog");
+            AlertDialog dialog1 = (AlertDialog) ShadowDialog.getLatestDialog();
+            assertNotNull(dialog1);
+            clickDialogListItem(dialog1, 1);
+            Shadows.shadowOf(Looper.getMainLooper()).idle();
+            assertNotNull(ShadowDialog.getLatestDialog());
+
+            invokePrivate(activity, "showFilterDialog");
+            AlertDialog dialog2 = (AlertDialog) ShadowDialog.getLatestDialog();
+            assertNotNull(dialog2);
+            clickDialogListItem(dialog2, 2);
+            Shadows.shadowOf(Looper.getMainLooper()).idle();
+            assertNotNull(ShadowDialog.getLatestDialog());
+        }
+    }
+    private void clickDialogListItem(AlertDialog dialog, int index) {
+        ListView lv = dialog.getListView();
+        assertNotNull(lv);
+
+        lv.measure(View.MeasureSpec.makeMeasureSpec(1000, View.MeasureSpec.AT_MOST), View.MeasureSpec.makeMeasureSpec(1000, View.MeasureSpec.AT_MOST));
+        lv.layout(0, 0, 1000, 1000);
+
+        View row = lv.getAdapter().getView(index, null, lv);
+        lv.performItemClick(row, index, lv.getAdapter().getItemId(index));
+    }
+    @Test
+    public void showLocationInputDialog_clickSearch_runsPositiveHandler() throws Exception {
+        MainActivity activity;
+        try (ActivityController<MainActivity> controller = Robolectric.buildActivity(MainActivity.class).create()) {
+            activity = controller.get();
+
+            invokePrivate(activity, "showLocationInputDialog");
+
+            AlertDialog dialog = (AlertDialog) ShadowDialog.getLatestDialog();
+            assertNotNull(dialog);
+
+            TextInputEditText input = findFirstTextInputEditText(dialog.getWindow().getDecorView());
+            assertNotNull(input);
+            input.setText(" New York ");
+
+            assertNotNull(dialog.getButton(AlertDialog.BUTTON_POSITIVE));
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE).performClick();
+
+            Shadows.shadowOf(Looper.getMainLooper()).idle();
+        }
+    }
+    @Test
+    public void showCategoryInputDialog_clickApply_runsPositiveHandler() throws Exception {
+        MainActivity activity;
+        try (ActivityController<MainActivity> controller = Robolectric.buildActivity(MainActivity.class).create()) {
+            activity = controller.get();
+
+            invokePrivate(activity, "showCategoryInputDialog");
+
+            AlertDialog dialog = (AlertDialog) ShadowDialog.getLatestDialog();
+            assertNotNull(dialog);
+
+            TextInputEditText input = findFirstTextInputEditText(dialog.getWindow().getDecorView());
+            assertNotNull(input);
+            input.setText(" movies ");
+
+            assertNotNull(dialog.getButton(AlertDialog.BUTTON_POSITIVE));
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE).performClick();
+
+            Shadows.shadowOf(Looper.getMainLooper()).idle();
+        }
+    }
+    @Test
+    public void showDatePickerDialog_triggersOnDateSetListener_viaReflection() throws Exception {
+        MainActivity activity;
+        try (ActivityController<MainActivity> controller = Robolectric.buildActivity(MainActivity.class).create()) {
+            activity = controller.get();
+
+            invokePrivate(activity, "showDatePickerDialog");
+
+            android.app.Dialog latest = org.robolectric.shadows.ShadowDialog.getLatestDialog();
+            assertNotNull(latest);
+
+            android.app.DatePickerDialog dp = (android.app.DatePickerDialog) latest;
+
+            java.lang.reflect.Field f = android.app.DatePickerDialog.class.getDeclaredField("mDateSetListener");
+            f.setAccessible(true);
+            android.app.DatePickerDialog.OnDateSetListener listener = (android.app.DatePickerDialog.OnDateSetListener) f.get(dp);
+
+            assertNotNull(listener);
+
+            listener.onDateSet(dp.getDatePicker(), 2026, 0, 15);
+            org.robolectric.Shadows.shadowOf(android.os.Looper.getMainLooper()).idle();
+        }
+    }
+    @Test
+    public void applyFilter_none_and_category_executes() throws Exception {
+        MainActivity activity;
+        try (ActivityController<MainActivity> controller = Robolectric.buildActivity(MainActivity.class).create()) {
+            activity = controller.get();
+
+            invokePrivate(activity, "applyFilter", new Class<?>[]{EventFilter.class}, EventFilter.none());
+            invokePrivate(activity, "applyFilter", new Class<?>[]{EventFilter.class}, EventFilter.category("movies"));
+
+            Shadows.shadowOf(Looper.getMainLooper()).idle();
+        }
+    }
+    @Test
+    public void confirmCancelReservation_clickPositive_executesCancelReservation() throws Exception {
+        when(TestMainActivity.AUTH.getCurrentUser()).thenReturn(null);
+
+        when(TestMainActivity.DB.runTransaction(any(Transaction.Function.class)))
+                .thenReturn(Tasks.forException(new RuntimeException("boom")));
+
+        DocumentReference reservationDoc = mock(DocumentReference.class);
+        when(TestMainActivity.RESERVATIONS_REF.document("res-1")).thenReturn(reservationDoc);
+
+        try (ActivityController<TestMainActivity> controller = Robolectric.buildActivity(TestMainActivity.class).create()) {
+
+            TestMainActivity activity = controller.get();
+
+            Reservation r = new Reservation();
+            r.setId("res-1");
+
+            invokePrivate(activity, "confirmCancelReservation", new Class<?>[]{Reservation.class}, r);
+
+            AlertDialog dialog = (AlertDialog) ShadowDialog.getLatestDialog();
+            assertNotNull(dialog);
+
+            ShadowToast.reset();
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE).performClick();
+            Shadows.shadowOf(Looper.getMainLooper()).idle();
+
+            assertEquals(activity.getString(R.string.cancel_reservation_failed), ShadowToast.getTextOfLatestToast());
+        }
+    }
+    @Test
+    public void showEventsTab_whenFilterAppliedAndEmpty_showsNoMatchingResultsText() throws Exception {
+        MainActivity activity;
+        try (ActivityController<MainActivity> controller = Robolectric.buildActivity(MainActivity.class).create()) {
+            activity = controller.get();
+
+            setPrivateField(activity, "filterApplied", true);
+
+            setPrivateField(activity, "eventAdapter", null);
+
+            invokePrivate(activity, "showEventsTab");
+
+            RecyclerView rvEvents = getPrivateField(activity, "rvEvents", RecyclerView.class);
+            assertEquals(View.VISIBLE, rvEvents.getVisibility());
+
+            View tvNoMatching = activity.findViewById(R.id.tvNoMatchingResultsFromFilter);
+            assertNotNull(tvNoMatching);
+
+            assertEquals(View.VISIBLE, tvNoMatching.getVisibility());
+        }
+    }
+    @Test
+    public void showReservationsTab_whenNoAdapter_showsEmptyReservationsText() throws Exception {
+        MainActivity activity;
+        try (ActivityController<MainActivity> controller = Robolectric.buildActivity(MainActivity.class).create()) {
+            activity = controller.get();
+
+            setPrivateField(activity, "reservationAdapter", null);
+
+            FirebaseAuth auth = mock(FirebaseAuth.class);
+            when(auth.getCurrentUser()).thenReturn(null);
+            setPrivateField(activity, "auth", auth);
+
+            invokePrivate(activity, "showReservationsTab");
+
+            RecyclerView rvEvents = getPrivateField(activity, "rvEvents", RecyclerView.class);
+            RecyclerView rvReservations = getPrivateField(activity, "rvReservations", RecyclerView.class);
+            TabLayout tabs = getPrivateField(activity, "reservationsTabs", TabLayout.class);
+
+            assertEquals(View.GONE, rvEvents.getVisibility());
+            assertEquals(View.VISIBLE, tabs.getVisibility());
+            assertEquals(View.VISIBLE, rvReservations.getVisibility());
+
+            View tvEmpty = activity.findViewById(R.id.tvEmptyReservations);
+            assertNotNull(tvEmpty);
+
+            assertEquals(View.VISIBLE, tvEmpty.getVisibility());
+        }
     }
 }


### PR DESCRIPTION
Added some unit tests to increase coverage of EventQueryBuilder
Added some unit tests (robolectric and mockito to mock firebase) to MainActivity: cancel/reserve/confirm, ui popups and input fields are present and appear when expected, checks ui visibility when expected