### PR TITLE
Refactor auth-related activities to improve testability and add unit tests.

### DIFF
--- a/app/src/main/java/com/example/ticketreservationapp/ConfirmEmailActivity.java
+++ b/app/src/main/java/com/example/ticketreservationapp/ConfirmEmailActivity.java
@@ -14,12 +14,15 @@ import com.google.firebase.auth.FirebaseUser;
 
 
 public class ConfirmEmailActivity extends AppCompatActivity {
+    Button confirmButton;
+    FirebaseAuth auth;
+
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_confirm_email);
-        FirebaseAuth auth = FirebaseAuth.getInstance();
+        auth = FirebaseAuth.getInstance();
         FirebaseUser user = auth.getCurrentUser();
         if (user == null) {
             startActivity(new Intent(ConfirmEmailActivity.this, LogInActivity.class));
@@ -27,25 +30,27 @@ public class ConfirmEmailActivity extends AppCompatActivity {
             return;
         }
         user.sendEmailVerification();
-        Button confirmButton = findViewById(R.id.confirm_button);
+        confirmButton = findViewById(R.id.confirm_button);
         confirmButton.setOnClickListener(v -> checkEmailVerification(user));
 
     }
 
     private void checkEmailVerification(FirebaseUser user) {
         Task<Void> reload = user.reload();
-        reload.addOnCompleteListener(this, task -> {
-            if (task.isSuccessful()) {
-                if (user.isEmailVerified()) {
-                    startActivity(new Intent(ConfirmEmailActivity.this, MainActivity.class));
-                    finish();
-                } else {
-                    Toast.makeText(this, "Please verify your email", Toast.LENGTH_LONG).show();
-                }
-            }else{
-                Toast.makeText(this, "Failed to reload user", Toast.LENGTH_LONG).show();
+        reload.addOnCompleteListener(this, this::handleEmailVerificationResult);
+    }
+
+    void handleEmailVerificationResult(Task<Void> task) {
+        if (task.isSuccessful()) {
+            if (auth.getCurrentUser() != null && auth.getCurrentUser().isEmailVerified()) {
+                startActivity(new Intent(ConfirmEmailActivity.this, MainActivity.class));
+                finish();
+            } else {
+                Toast.makeText(this, "Please verify your email", Toast.LENGTH_LONG).show();
             }
-        });
+        }else{
+            Toast.makeText(this, "Failed to reload user", Toast.LENGTH_LONG).show();
+        }
     }
 
 }

--- a/app/src/main/java/com/example/ticketreservationapp/ConfirmPhoneActivity.java
+++ b/app/src/main/java/com/example/ticketreservationapp/ConfirmPhoneActivity.java
@@ -9,7 +9,9 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.google.android.gms.tasks.Task;
 import com.google.firebase.FirebaseException;
+import com.google.firebase.auth.AuthResult;
 import com.google.firebase.auth.FirebaseAuth;
 
 import com.google.firebase.auth.PhoneAuthCredential;
@@ -20,9 +22,9 @@ import com.google.firebase.auth.PhoneAuthProvider;
 
 public class ConfirmPhoneActivity extends AppCompatActivity {
 
-    private FirebaseAuth auth;
+    FirebaseAuth auth;
 
-    private String verificationId;
+    String verificationId;
 
     PhoneAuthProvider.ForceResendingToken token;
 
@@ -62,7 +64,7 @@ public class ConfirmPhoneActivity extends AppCompatActivity {
 
     }
 
-    private PhoneAuthOptions getOptions(String phoneString) {
+    PhoneAuthOptions getOptions(String phoneString) {
         return new PhoneAuthOptions.Builder(auth)
                 .setPhoneNumber(phoneString)
                 .setTimeout(60L, java.util.concurrent.TimeUnit.SECONDS)
@@ -71,7 +73,7 @@ public class ConfirmPhoneActivity extends AppCompatActivity {
                 .build();
     }
 
-    private PhoneAuthProvider.OnVerificationStateChangedCallbacks getCallbacks() {
+    PhoneAuthProvider.OnVerificationStateChangedCallbacks getCallbacks() {
         return new PhoneAuthProvider.OnVerificationStateChangedCallbacks() {
             @Override
             public void onVerificationCompleted(@NonNull PhoneAuthCredential credential) {
@@ -93,18 +95,19 @@ public class ConfirmPhoneActivity extends AppCompatActivity {
         };
     }
     void signInWithPhoneAuthCredential(PhoneAuthCredential credential) {
-        auth.signInWithCredential(credential)
-            .addOnCompleteListener(this, task1 -> {
-                if (task1.isSuccessful()) {
-                    Toast.makeText(ConfirmPhoneActivity.this, "Login successful", Toast.LENGTH_LONG).show();
-                    startActivity(new Intent(ConfirmPhoneActivity.this, MainActivity.class));
-                    finish();
-                } else {
-                    Toast.makeText(ConfirmPhoneActivity.this, "Login failed", Toast.LENGTH_LONG).show();
-                    startActivity(new Intent(ConfirmPhoneActivity.this, LogInActivity.class));
-                    finish();
-                }
-            });
+        auth.signInWithCredential(credential).addOnCompleteListener(this, this::handleLoginResult);
+    }
+
+    void handleLoginResult(Task<AuthResult> task) {
+        if (task.isSuccessful()) {
+            Toast.makeText(ConfirmPhoneActivity.this, "Login successful", Toast.LENGTH_LONG).show();
+            startActivity(new Intent(ConfirmPhoneActivity.this, MainActivity.class));
+            finish();
+        } else {
+            Toast.makeText(ConfirmPhoneActivity.this, "Login failed", Toast.LENGTH_LONG).show();
+            startActivity(new Intent(ConfirmPhoneActivity.this, LogInActivity.class));
+            finish();
+        }
     }
 }
 

--- a/app/src/main/java/com/example/ticketreservationapp/LogInActivity.java
+++ b/app/src/main/java/com/example/ticketreservationapp/LogInActivity.java
@@ -10,15 +10,23 @@ import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.auth.AuthResult;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.PhoneAuthProvider;
 
 
 public class LogInActivity extends AppCompatActivity {
 
-    private EditText email, password, phone;
+    EditText email;
+    EditText password;
+    EditText phone;
 
-    private FirebaseAuth auth;
+    Button logMail, logPhone;
+
+    TextView registerLink;
+
+    FirebaseAuth auth;
 
     private PhoneAuthProvider.OnVerificationStateChangedCallbacks callbacks;
 
@@ -36,16 +44,16 @@ public class LogInActivity extends AppCompatActivity {
         password = findViewById(R.id.password_edittext);
         phone = findViewById(R.id.phone_edittext);
 
-        TextView registerLink = findViewById(R.id.register_link);
+        registerLink = findViewById(R.id.register_link);
         registerLink.setOnClickListener(v -> {
             startActivity(new Intent(LogInActivity.this, RegisterActivity.class));
             finish();
         });
 
 
-        Button logMail = findViewById(R.id.loginMail_button);
+        logMail = findViewById(R.id.loginMail_button);
         logMail.setOnClickListener(v -> logInWithEmail(email.getText().toString().trim(), password.getText().toString().trim()));
-        Button logPhone = findViewById(R.id.loginPhone_button);
+        logPhone = findViewById(R.id.loginPhone_button);
         logPhone.setOnClickListener(v -> logInWithPhone(phone.getText().toString().trim()));
     }
 
@@ -56,18 +64,7 @@ public class LogInActivity extends AppCompatActivity {
             return;
         }
 
-        auth.signInWithEmailAndPassword(mailString, pass).addOnCompleteListener(this, task -> {
-            if (task.isSuccessful()) {
-                Toast.makeText(LogInActivity.this, "Login successful!", Toast.LENGTH_LONG).show();
-                // Navigate to MainActivity
-                startActivity(new Intent(LogInActivity.this, MainActivity.class));
-                finish();
-            } else {
-                // Login failed
-                Toast.makeText(LogInActivity.this, "Login failed! Please try again later", Toast.LENGTH_LONG).show();
-
-            }
-        });
+        auth.signInWithEmailAndPassword(mailString, pass).addOnCompleteListener(this, this::handleLoginResult);
     }
 
     void logInWithPhone(String phoneString) {
@@ -84,6 +81,19 @@ public class LogInActivity extends AppCompatActivity {
         Authentification.phone = "+1" + phoneString;
         startActivity(new Intent(LogInActivity.this, ConfirmPhoneActivity.class));
         finish();
+    }
+
+    void handleLoginResult(Task<AuthResult> task) {
+        if (task.isSuccessful()) {
+            Toast.makeText(LogInActivity.this, "Login successful!", Toast.LENGTH_LONG).show();
+            // Navigate to MainActivity
+            startActivity(new Intent(LogInActivity.this, MainActivity.class));
+            finish();
+        } else {
+            // Login failed
+            Toast.makeText(LogInActivity.this, "Login failed! Please try again later", Toast.LENGTH_LONG).show();
+
+        }
     }
 
 }

--- a/app/src/main/java/com/example/ticketreservationapp/RegisterActivity.java
+++ b/app/src/main/java/com/example/ticketreservationapp/RegisterActivity.java
@@ -14,14 +14,17 @@ import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.auth.AuthResult;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseAuthUserCollisionException;
 
 
 public class RegisterActivity extends AppCompatActivity {
-    private EditText email, confirmPassword, password;
+    EditText email, confirmPassword, password;
 
-    private FirebaseAuth auth;
+    Button registerMail;
+    FirebaseAuth auth;
 
 
     @Override
@@ -37,7 +40,7 @@ public class RegisterActivity extends AppCompatActivity {
         password = findViewById(id.password_edittext);
         confirmPassword = findViewById(id.confirmPassword_edittext);
 
-        Button registerMail = findViewById(id.registerMail_button);
+        registerMail = findViewById(id.registerMail_button);
         registerMail.setOnClickListener(v -> registerWithEmail(email.getText().toString().trim().toLowerCase(),password.getText().toString().trim(),confirmPassword.getText().toString().trim()));
     }
 
@@ -60,26 +63,28 @@ public class RegisterActivity extends AppCompatActivity {
 
             // Register user with email and password
              auth.createUserWithEmailAndPassword(authString, pass)
-                     .addOnCompleteListener(this, task -> {
-                         // Registration successful
-                         if (task.isSuccessful()) {
-                             // Navigate to MainActivity
-                             Toast.makeText(RegisterActivity.this, "Registration successful!", Toast.LENGTH_LONG).show();
-                             startActivity(new Intent(RegisterActivity.this, ConfirmEmailActivity.class));
-                             finish();
-                         }
-                         // Registration failed
-                         //User is already registered
-                         else if (task.getException() instanceof FirebaseAuthUserCollisionException){
-                             Toast.makeText(RegisterActivity.this, "You're already register please log in", Toast.LENGTH_LONG).show();
-                             startActivity(new Intent(RegisterActivity.this, LogInActivity.class));
-                             finish();
-                         } else {
-                             Toast.makeText(RegisterActivity.this, "Registration failed! Please try again later", Toast.LENGTH_LONG).show();
-                         }
-                     });
+                     .addOnCompleteListener(this, this::handleRegistrationResult);
         } else{
             Toast.makeText(this, "Please enter a valid email", Toast.LENGTH_LONG).show();
+        }
+    }
+
+    public void handleRegistrationResult(Task<AuthResult> task) {
+        // Registration successful
+        if (task.isSuccessful()) {
+            // Navigate to MainActivity
+            Toast.makeText(RegisterActivity.this, "Registration successful!", Toast.LENGTH_LONG).show();
+            startActivity(new Intent(RegisterActivity.this, ConfirmEmailActivity.class));
+            finish();
+        }
+        // Registration failed
+        //User is already registered
+        else if (task.getException() instanceof FirebaseAuthUserCollisionException){
+            Toast.makeText(RegisterActivity.this, "You're already register please log in", Toast.LENGTH_LONG).show();
+            startActivity(new Intent(RegisterActivity.this, LogInActivity.class));
+            finish();
+        } else {
+            Toast.makeText(RegisterActivity.this, "Registration failed! Please try again later", Toast.LENGTH_LONG).show();
         }
     }
 }

--- a/app/src/test/java/com/example/ticketreservationapp/AuthentificationTest.java
+++ b/app/src/test/java/com/example/ticketreservationapp/AuthentificationTest.java
@@ -1,0 +1,40 @@
+package com.example.ticketreservationapp;
+
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.DocumentReference;
+import com.google.firebase.firestore.FirebaseFirestore;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.Map;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 34)
+public class AuthentificationTest {
+
+    @Test
+    public void setAdminTest(){
+        FirebaseFirestore db = mock(FirebaseFirestore.class);
+        CollectionReference collectionRef = mock(CollectionReference.class);
+        DocumentReference docRef = mock(DocumentReference.class);
+        when(db.collection("users")).thenReturn(collectionRef);
+        when(collectionRef.document("uid")).thenReturn(docRef);
+        try(MockedStatic<FirebaseFirestore> mockedStatic = mockStatic(FirebaseFirestore.class)){
+            mockedStatic.when(FirebaseFirestore::getInstance).thenReturn(db);
+            Authentification.setAdmin("uid", true);
+            verify(docRef).set(Map.of("isAdmin", true));
+            Authentification.setAdmin("uid", false);
+            verify(docRef).set(Map.of("isAdmin", false));
+        }
+    }
+}

--- a/app/src/test/java/com/example/ticketreservationapp/ConfirmEmailTest.java
+++ b/app/src/test/java/com/example/ticketreservationapp/ConfirmEmailTest.java
@@ -1,0 +1,102 @@
+package com.example.ticketreservationapp;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseUser;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowToast;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 34)
+public class ConfirmEmailTest {
+
+    @Test
+    public void onCreateNullUserTest(){
+        ConfirmEmailActivity activity;
+        try (ActivityController<ConfirmEmailActivity> controller = Robolectric.buildActivity(ConfirmEmailActivity.class)) {
+            activity = controller.get();
+        }
+        FirebaseAuth auth = mock(FirebaseAuth.class);
+        try(MockedStatic<FirebaseAuth> mockedAuth = mockStatic(FirebaseAuth.class)){
+            mockedAuth.when(FirebaseAuth::getInstance).thenReturn(auth);
+            activity.onCreate(null);
+            assert(activity.isFinishing());
+        }
+
+    }
+
+    @Test
+    public void onCreateTest(){
+        ConfirmEmailActivity activity;
+        try (ActivityController<ConfirmEmailActivity> controller = Robolectric.buildActivity(ConfirmEmailActivity.class)) {
+            activity = controller.get();
+        }
+
+        FirebaseAuth auth = mock(FirebaseAuth.class);
+        FirebaseUser user = mock(FirebaseUser.class);
+        when(auth.getCurrentUser()).thenReturn(user);
+        try(MockedStatic<FirebaseAuth> mockedAuth = mockStatic(FirebaseAuth.class)){
+            mockedAuth.when(FirebaseAuth::getInstance).thenReturn(auth);
+            activity.onCreate(null);
+            assert(activity.confirmButton.equals(activity.findViewById(R.id.confirm_button)));
+
+            Task<Void> reload = mock(Task.class);
+            when(user.reload()).thenReturn(reload);
+            Task<Void> task = mock(Task.class);
+            activity.confirmButton.performClick();
+            verify(reload).addOnCompleteListener(any(ConfirmEmailActivity.class), any(OnCompleteListener.class));
+        }
+
+    }
+
+    @Test
+    public void handleEmailVerificationResultTest() {
+        ConfirmEmailActivity activity;
+        try (ActivityController<ConfirmEmailActivity> controller = Robolectric.buildActivity(ConfirmEmailActivity.class)) {
+            activity = controller.get();
+        }
+        FirebaseAuth auth = mock(FirebaseAuth.class);
+        FirebaseUser user = mock(FirebaseUser.class);
+        when(auth.getCurrentUser()).thenReturn(user);
+        Task<Void> task = mock(Task.class);
+        activity.auth = auth;
+
+        //Test successful verification
+        when(user.isEmailVerified()).thenReturn(true);
+        when(task.isSuccessful()).thenReturn(true);
+        activity.handleEmailVerificationResult(task);
+        assert(activity.isFinishing());
+
+        //Test failed verification
+        when(user.isEmailVerified()).thenReturn(false);
+        when(task.isSuccessful()).thenReturn(true);
+        activity.handleEmailVerificationResult(task);
+        assert(ShadowToast.getTextOfLatestToast().equals("Please verify your email"));
+
+        //Test null user
+        when(auth.getCurrentUser()).thenReturn(null);
+        activity.handleEmailVerificationResult(task);
+        assert(ShadowToast.getTextOfLatestToast().equals("Please verify your email"));
+
+
+        //Test failed task
+        when(task.isSuccessful()).thenReturn(false);
+        activity.handleEmailVerificationResult(task);
+        assert(ShadowToast.getTextOfLatestToast().equals("Failed to reload user"));
+
+    }
+}

--- a/app/src/test/java/com/example/ticketreservationapp/ConfirmPhoneTest.java
+++ b/app/src/test/java/com/example/ticketreservationapp/ConfirmPhoneTest.java
@@ -1,9 +1,22 @@
 package com.example.ticketreservationapp;
 
-import androidx.test.ext.junit.runners.AndroidJUnit4;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.FirebaseException;
+import com.google.firebase.auth.AuthResult;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.PhoneAuthCredential;
+import com.google.firebase.auth.PhoneAuthOptions;
+import com.google.firebase.auth.PhoneAuthProvider;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
@@ -15,6 +28,28 @@ import java.util.HashMap;
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 34)
 public class ConfirmPhoneTest {
+
+    @Test
+    public void onCreateTest() {
+        ConfirmPhoneActivity activity;
+        try (ActivityController<ConfirmPhoneActivity> controller = Robolectric.buildActivity(ConfirmPhoneActivity.class)) {
+            activity = controller.get();
+        }
+        FirebaseAuth auth = mock(FirebaseAuth.class);
+        try(MockedStatic<FirebaseAuth> mockedAuth = mockStatic(FirebaseAuth.class)){
+            mockedAuth.when(FirebaseAuth::getInstance).thenReturn(auth);
+            Authentification.phone = "1234567890";
+            activity.onCreate(null);
+            assert(activity.auth.equals(auth));
+            assert(activity.verificationId == null);
+            assert(activity.token == null);
+            assert(activity.findViewById(R.id.code_edittext).equals(activity.findViewById(R.id.code_edittext)));
+            assert(activity.findViewById(R.id.confirm_button).equals(activity.findViewById(R.id.confirm_button)));
+
+            activity.findViewById(R.id.confirm_button).performClick();
+            assert(ShadowToast.getTextOfLatestToast().equals("Please enter the code"));
+        }
+    }
 
     @Test
     public void confirmPhoneTest(){
@@ -29,12 +64,88 @@ public class ConfirmPhoneTest {
             activity = controller.get();
         }
 
+        //Test invalid input
         for (String code : map.keySet()) {
             ShadowToast.reset();
             activity.confirmPhone(code);
             String toastText = ShadowToast.getTextOfLatestToast();
             assert(map.get(code).equals(toastText));
         }
+
+        //Test valid input
+        activity.verificationId = "1234567890";
+        activity.auth = mock(FirebaseAuth.class);
+        PhoneAuthCredential credential = mock(PhoneAuthCredential.class);
+        Task<AuthResult> task = mock(Task.class);
+        when(activity.auth.signInWithCredential(credential)).thenReturn(task);
+        when(task.isSuccessful()).thenReturn(true);
+
+        try(MockedStatic<PhoneAuthProvider> mockedAuth = mockStatic(PhoneAuthProvider.class)){
+            mockedAuth.when(() -> PhoneAuthProvider.getCredential(activity.verificationId, "123456")).thenReturn(credential);
+            activity.confirmPhone("123456");
+            verify(activity.auth).signInWithCredential(credential);
+        }
+
+    }
+
+    @Test
+    public void getOptionsTest(){
+        ConfirmPhoneActivity activity;
+        try (ActivityController<ConfirmPhoneActivity> controller = Robolectric.buildActivity(ConfirmPhoneActivity.class)) {
+            activity = controller.get();
+        }
+        activity.auth = mock(FirebaseAuth.class);
+        PhoneAuthOptions options = activity.getOptions("1234567890");
+        assert(options != null);
+    }
+
+    @Test
+    public void callbacksTest(){
+        ConfirmPhoneActivity activity;
+        try (ActivityController<ConfirmPhoneActivity> controller = Robolectric.buildActivity(ConfirmPhoneActivity.class)) {
+            activity = controller.get();
+        }
+        activity.auth = mock(FirebaseAuth.class);
+        PhoneAuthProvider.OnVerificationStateChangedCallbacks callbacks = activity.getCallbacks();
+
+        //Test onCodeSent
+        PhoneAuthProvider.ForceResendingToken token = mock(PhoneAuthProvider.ForceResendingToken.class);
+        callbacks.onCodeSent("1234567890", token);
+        assert(activity.verificationId.equals("1234567890"));
+        assert(activity.token.equals(token));
+        assert(ShadowToast.getTextOfLatestToast().equals("Verify your SMS Inbox"));
+
+        //Test OnVerificationFailed
+        FirebaseException exception = mock(FirebaseException.class);
+        when(exception.getMessage()).thenReturn("Error");
+        callbacks.onVerificationFailed(exception);
+        assert(ShadowToast.getTextOfLatestToast().equals("Error"));
+
+        //Test onVerificationCompleted
+        PhoneAuthCredential credential = mock(PhoneAuthCredential.class);
+        Task<AuthResult> task = mock(Task.class);
+        when(activity.auth.signInWithCredential(credential)).thenReturn(task);
+        callbacks.onVerificationCompleted(credential);
+        verify(activity.auth).signInWithCredential(credential);
+    }
+
+    @Test
+    public void handleLoginResultTest(){
+        ConfirmPhoneActivity activity;
+        try (ActivityController<ConfirmPhoneActivity> controller = Robolectric.buildActivity(ConfirmPhoneActivity.class)) {
+            activity = controller.get();
+        }
+
+        //Test successful login
+        Task<AuthResult> task = mock(Task.class);
+        when(task.isSuccessful()).thenReturn(true);
+        activity.handleLoginResult(task);
+        assert(ShadowToast.getTextOfLatestToast().equals("Login successful"));
+
+        //Test failed login
+        when(task.isSuccessful()).thenReturn(false);
+        activity.handleLoginResult(task);
+        assert(ShadowToast.getTextOfLatestToast().equals("Login failed"));
     }
 
 

--- a/app/src/test/java/com/example/ticketreservationapp/LogInActivityTest.java
+++ b/app/src/test/java/com/example/ticketreservationapp/LogInActivityTest.java
@@ -1,11 +1,20 @@
 package com.example.ticketreservationapp;
 
 
-import androidx.test.ext.junit.runners.AndroidJUnit4;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import org.junit.BeforeClass;
+
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.auth.AuthResult;
+import com.google.firebase.auth.FirebaseAuth;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
@@ -17,6 +26,35 @@ import java.util.HashMap;
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 34)
 public class LogInActivityTest {
+
+    @Test
+    public void onCreateTest(){
+        LogInActivity activity;
+        try (ActivityController<LogInActivity> controller = Robolectric.buildActivity(LogInActivity.class)) {
+            activity = controller.get();
+        }
+        FirebaseAuth auth = mock(FirebaseAuth.class);
+        try(MockedStatic<FirebaseAuth> mockedAuth = mockStatic(FirebaseAuth.class)){
+            mockedAuth.when(FirebaseAuth::getInstance).thenReturn(auth);
+            activity.onCreate(null);
+            assert(activity.auth.equals(auth));
+            assert(activity.email.equals(activity.findViewById(R.id.email_edittext)));
+            assert(activity.password.equals(activity.findViewById(R.id.password_edittext)));
+            assert(activity.phone.equals(activity.findViewById(R.id.phone_edittext)));
+            assert(activity.registerLink.equals(activity.findViewById(R.id.register_link)));
+            assert(activity.logMail.equals(activity.findViewById(R.id.loginMail_button)));
+            assert(activity.logPhone.equals(activity.findViewById(R.id.loginPhone_button)));
+
+            activity.registerLink.performClick();
+            assert(activity.isFinishing());
+
+            activity.logMail.performClick();
+            assert(ShadowToast.getTextOfLatestToast().equals("Please enter credentials"));
+
+            activity.logPhone.performClick();
+            assert(ShadowToast.getTextOfLatestToast().equals("Please enter a phone number"));
+        }
+    }
 
     @Test
     public void logInWithEmailTest(){
@@ -34,6 +72,31 @@ public class LogInActivityTest {
             String toastText = ShadowToast.getTextOfLatestToast();
             assert("Please enter credentials".equals(toastText));
         }
+
+        activity.auth = mock(FirebaseAuth.class);
+        Task<AuthResult> task = mock(Task.class);
+        when(task.isSuccessful()).thenReturn(true);
+        when(activity.auth.signInWithEmailAndPassword(anyString(), anyString())).thenReturn(task);
+        activity.logInWithEmail("test@gmail.com", "Password1234!");
+        verify(activity.auth).signInWithEmailAndPassword(anyString(), anyString());
+    }
+
+    @Test
+    public void handleLoginResultTest() {
+        LogInActivity activity;
+        try (ActivityController<LogInActivity> controller = Robolectric.buildActivity(LogInActivity.class)) {
+            activity = controller.get();
+        }
+        //Test successful login
+        Task<AuthResult> task = mock(Task.class);
+        when(task.isSuccessful()).thenReturn(true);
+        activity.handleLoginResult(task);
+        assert(ShadowToast.getTextOfLatestToast().equals("Login successful!"));
+
+        //Test failed login
+        when(task.isSuccessful()).thenReturn(false);
+        activity.handleLoginResult(task);
+        assert(ShadowToast.getTextOfLatestToast().equals("Login failed! Please try again later"));
     }
 
     @Test

--- a/app/src/test/java/com/example/ticketreservationapp/MainActivityTest.java
+++ b/app/src/test/java/com/example/ticketreservationapp/MainActivityTest.java
@@ -174,7 +174,7 @@ public class MainActivityTest {
 
         invokePrivate(activity, "checkUserStatus", new Class<?>[]{FirebaseUser.class}, new Object[]{null});
 
-        assertEquals(true, activity.isFinishing());
+        assert(activity.isFinishing());
     }
 
     private void invokePrivate(MainActivity activity, String methodName, Class<?>[] argTypes, Object... args) throws Exception {

--- a/app/src/test/java/com/example/ticketreservationapp/RegisterActivityTest.java
+++ b/app/src/test/java/com/example/ticketreservationapp/RegisterActivityTest.java
@@ -1,10 +1,21 @@
 package com.example.ticketreservationapp;
 
 
-import androidx.test.ext.junit.runners.AndroidJUnit4;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.auth.AuthResult;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseAuthUserCollisionException;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
@@ -12,7 +23,6 @@ import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowToast;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 34)
@@ -43,7 +53,7 @@ public class RegisterActivityTest {
         testCases.add(new Data("test@gmail.com", "PASSWORD1234!", "PASSWORD1234!", "Password must contain at least 8 characters, one uppercase letter, one lowercase letter, one number, and one special character"));
         testCases.add(new Data("test@gmail.com", "Password!", "Password!", "Password must contain at least 8 characters, one uppercase letter, one lowercase letter, one number, and one special character"));
         testCases.add(new Data("test@gmail.com", "Password1234", "Password1234", "Password must contain at least 8 characters, one uppercase letter, one lowercase letter, one number, and one special character"));
-
+        testCases.add(new Data("testgmail.com", "Password1234!", "Password1234!", "Please enter a valid email"));
         RegisterActivity activity;
         try (ActivityController<RegisterActivity> controller = Robolectric.buildActivity(RegisterActivity.class)) {
             activity = controller.get();
@@ -53,6 +63,59 @@ public class RegisterActivityTest {
             activity.registerWithEmail(testCase.email, testCase.password, testCase.confirmPassword);
             String toastText = ShadowToast.getTextOfLatestToast();
             assert(testCase.toastText.equals(toastText));
+        }
+        activity.auth = mock(FirebaseAuth.class);
+        Task<AuthResult> task = mock(Task.class);
+        when(task.isSuccessful()).thenReturn(true);
+        when(activity.auth.createUserWithEmailAndPassword(anyString(), anyString())).thenReturn(task);
+        activity.registerWithEmail("test@gmail.com", "Password1234!", "Password1234!");
+        verify(activity.auth).createUserWithEmailAndPassword(anyString(), anyString());
+    }
+
+    @Test
+    public void handleRegistrationResultTest(){
+        RegisterActivity activity;
+        try (ActivityController<RegisterActivity> controller = Robolectric.buildActivity(RegisterActivity.class)) {
+            activity = controller.get();
+        }
+
+        //Test successful registration
+        Task<AuthResult> task = mock(Task.class);
+        when(task.isSuccessful()).thenReturn(true);
+        activity.handleRegistrationResult(task);
+        assert(ShadowToast.getTextOfLatestToast().equals("Registration successful!"));
+
+        //Test failed registration with FirebaseAuthUserCollisionException
+        when(task.isSuccessful()).thenReturn(false);
+        FirebaseAuthUserCollisionException exception = new FirebaseAuthUserCollisionException("Error","Error");
+        when(task.getException()).thenReturn(exception);
+        activity.handleRegistrationResult(task);
+        assert(ShadowToast.getTextOfLatestToast().equals("You're already register please log in"));
+
+        //Test failed registration with other exception
+        when(task.isSuccessful()).thenReturn(false);
+        when(task.getException()).thenReturn(new Exception());
+        activity.handleRegistrationResult(task);
+        assert(ShadowToast.getTextOfLatestToast().equals("Registration failed! Please try again later"));
+    }
+
+    @Test
+    public void onCreateTest(){
+        RegisterActivity activity;
+        try (ActivityController<RegisterActivity> controller = Robolectric.buildActivity(RegisterActivity.class)) {
+            activity = controller.get();
+        }
+        FirebaseAuth auth = mock(FirebaseAuth.class);
+        try(MockedStatic<FirebaseAuth> mockedStatic = Mockito.mockStatic(FirebaseAuth.class)){
+            mockedStatic.when(FirebaseAuth::getInstance).thenReturn(auth);
+            activity.onCreate(null);
+            assert(activity.auth.equals(FirebaseAuth.getInstance()));
+            assert(activity.email.equals(activity.findViewById(R.id.email_edittext)));
+            assert(activity.password.equals(activity.findViewById(R.id.password_edittext)));
+            assert(activity.confirmPassword.equals(activity.findViewById(R.id.confirmPassword_edittext)));
+            assert(activity.registerMail.equals(activity.findViewById(R.id.registerMail_button)));
+            activity.registerMail.performClick();
+            assert(ShadowToast.getTextOfLatestToast().equals("Please enter credentials"));
         }
     }
 }


### PR DESCRIPTION
- Refactor `ConfirmEmailActivity`, `RegisterActivity`, `LogInActivity`, and `ConfirmPhoneActivity` by extracting task completion logic into separate methods.
- Increase visibility of fields (e.g., `auth`, `confirmButton`, `email`) from private to package-private to allow access in tests.
- Add comprehensive unit tests for `ConfirmEmailActivity`, `RegisterActivity`, `LogInActivity`, `ConfirmPhoneActivity`, and `Authentification`.
- Update `MainActivityTest` to use `assert`